### PR TITLE
Update leave section - corrected media rule for retina background

### DIFF
--- a/src/css/layout/07-leave.css
+++ b/src/css/layout/07-leave.css
@@ -365,13 +365,16 @@
   }
 }
 
-/* @media screen and (min-device-pixel-ratio: 2) and (min-width: 1280px),
+@media screen and (min-device-pixel-ratio: 2) and (min-width: 1280px),
 screen and (min-resolution: 192dpi) and (min-width: 1280px),
 screen and (min-resolution: 2dppx) and (min-width: 1280px) {
   .leave__card-wrapper {
-      background-image: url('../../img/form-leave-2x.png');
-    }
-} */
+    background-image: url('../../img/form-leave-2x.png');
+    background-size: 492px;
+    background-position: top;
+
+  }
+}
 
 .leave__card-big-text {
   margin-bottom: 8px;

--- a/src/partials/07-leave.html
+++ b/src/partials/07-leave.html
@@ -1,8 +1,8 @@
 <section class="leave__section" id="leave-section">
   <div class="leave__container container">
-    <h1 class="leave__title" id="contact-us">
-      Leave an <span class="title-span">application</span>
-    </h1>
+    <h2 class="leave__title" id="contact-us">
+      Leave an <span class="text__element">application</span>
+    </h2>
     <p class="leave__text">
       Please use the form below to contact us. Enter your name, email, and
       message and we'll get back to you shortly.


### PR DESCRIPTION
updated media rule for retina screen %

@media screen and (min-device-pixel-ratio: 2) and (min-width: 1280px),
screen and (min-resolution: 192dpi) and (min-width: 1280px),
screen and (min-resolution: 2dppx) and (min-width: 1280px) {
  .leave__card-wrapper {
    background-image: url('../../img/form-leave-2x.png');
    background-size: 492px;
    background-position: top;

  }
}